### PR TITLE
Update for support for 1.16.X

### DIFF
--- a/Bungee/build.gradle
+++ b/Bungee/build.gradle
@@ -23,7 +23,7 @@ repositories {
     mavenLocal()
     maven { url "https://repository.jboss.org" }
     maven { url "https://jcenter.bintray.com" }
-    maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
+    maven { url "https://hub.spigotmc.org/nexus/content/groups/public/" }
     maven { url "https://maven.notfab.net/Hosted" }
     maven { url "https://repo.codemc.org/repository/maven-public" }
     maven { url "https://jitpack.io" }

--- a/Spigot/build.gradle
+++ b/Spigot/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile group: 'org.bstats', name: 'bstats-bukkit', version: '1.7'
 
     compileOnly group: 'me.clip', name: 'placeholderapi', version: '2.10.4'
-    compileOnly group: 'org.spigotmc', name: 'spigot', version: '1.15.2-R0.1-SNAPSHOT'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.16.2-R0.1-SNAPSHOT'
     //compileOnly group: 'org.spigotmc', name: 'spigot', version: '1.8.8-R0.1-SNAPSHOT'
     compileOnly group: 'org.jetbrains', name: 'annotations', version: '18.0.0'
     testCompile group: 'junit', name: 'junit', version: '4.13'

--- a/Spigot/build.gradle
+++ b/Spigot/build.gradle
@@ -23,6 +23,7 @@ repositories {
     mavenLocal()
     maven { url "https://jcenter.bintray.com" }
     maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
+    maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
     maven { url "https://maven.notfab.net/Hosted" }
     maven { url "https://maven.notfab.net/SpigotMC" }
     maven { url "https://repo.codemc.org/repository/maven-public" }

--- a/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/CraftBukkitVersion.java
+++ b/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/CraftBukkitVersion.java
@@ -36,7 +36,9 @@ public enum CraftBukkitVersion {
 
     v1_14_X("1.14.x", 1.14, "v1_14_R1"),
 
-    v1_15_X("1.15.x", 1.15, "v1_15_R1");
+    v1_15_X("1.15.x", 1.15, "v1_15_R1"),
+
+    v1_16_X("1.16.x", 1.16, "v1_16_R1");
 
     private final String name;
     private final double version;


### PR DESCRIPTION
This pull requests fixes some dependency issues related to bungeecord and spigot APIs as well as adding nms support for 1.16. I have done some testing and haven't found any bugs in 1.16. I have not tested these changes on other Minecraft versions.