### PR TITLE
Proposed change to fix nbt item issues on "unsupported" versions

### DIFF
--- a/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/NMSVersion.java
+++ b/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/NMSVersion.java
@@ -40,9 +40,14 @@ public class NMSVersion {
     }
 
     public String getRunningNMS() {
-        if (this.getRunningVersion().getName().equals("Unsupported"))
-            return Bukkit.getServer().getClass().getPackage().getName().substring(Bukkit.getServer().getClass().getPackage().getName().lastIndexOf(".") + 1);
-        return this.getRunningVersion().getNmsNames()[0];
+        CraftBukkitVersion version = this.getRunningVersion();
+
+        if (version == CraftBukkitVersion.UNSUPPORTED) {
+            String packageName = Bukkit.getServer().getClass().getPackage().getName();
+            return packageName.substring(packageName.lastIndexOf(".") + 1);
+        } else {
+            return version.getNmsNames()[0];
+        }
     }
 
 }

--- a/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/NMSVersion.java
+++ b/Spigot/src/main/java/net/notfab/hubbasics/spigot/nms/NMSVersion.java
@@ -40,6 +40,8 @@ public class NMSVersion {
     }
 
     public String getRunningNMS() {
+        if (this.getRunningVersion().getName().equals("Unsupported"))
+            return Bukkit.getServer().getClass().getPackage().getName().substring(Bukkit.getServer().getClass().getPackage().getName().lastIndexOf(".") + 1);
         return this.getRunningVersion().getNmsNames()[0];
     }
 


### PR DESCRIPTION
Many of my pull requests have centered around adding NMSVersions for newer Minecraft versions because the plugin's JoinItem module breaks after every update because the `getRunningNMS()` function returns "Unknown." This change will make it so the plugin uses the current NMS package when the NMSVersion is "Unsupported." I do concede this is more of a band aid fix to the problem, but it will fix issues for most users when there is an update to the API level that doesn't alter anything major. This also preserves the notion that the plugin is "unsupported" on those versions so server owners know that if they encounter issues its because the plugin hasn't been officially tested for that version.